### PR TITLE
modification to be bbox and route type generic

### DIFF
--- a/osm2gtfs.py
+++ b/osm2gtfs.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from osmhelper.osm_routes import Route, RouteMaster
 
 
+FLORIANOPOLIS = {"e":"-48.27117919921875", "n":"-27.215556209029675", "s":"-27.94103350326715", "w":"-49.0155029296875"}
+
 DEBUG_ROUTE = "104"
 
 START_DATE = "20160901"
@@ -35,10 +37,10 @@ def main():
         osmhelper.refresh_route(args.refresh_route)
         sys.exit(0)
     elif args.refresh_all_routes:
-        osmhelper.get_routes(refresh=True)
+        osmhelper.get_routes("bus", FLORIANOPOLIS, refresh=True)
         sys.exit(0)
     elif args.refresh_all_stops:
-        osmhelper.get_stops(osmhelper.get_routes(), refresh=True)
+        osmhelper.get_stops(osmhelper.get_routes("bus", FLORIANOPOLIS), refresh=True)
         sys.exit(0)
     elif args.refresh_all:
         osmhelper.refresh_data()
@@ -52,7 +54,7 @@ def main():
     linhas = json_data[0]['data']
 
     # Get OSM routes and check data
-    routes = osmhelper.get_routes()
+    routes = osmhelper.get_routes("bus", FLORIANOPOLIS)
 
     blacklist = ['10200', '12400', '328', '466', '665']
     # Try to find OSM routes in Fenix data

--- a/osmhelper/__init__.py
+++ b/osmhelper/__init__.py
@@ -12,7 +12,7 @@ from osmhelper.osm_stops import Stop
 
 CHECK_FOR_NON_PLATFORMS = False
 
-FLORIANOPOLIS = {"e":"-48.27117919921875", "n":"-27.215556209029675", "s":"-27.94103350326715", "w":"-49.0155029296875"}
+
 
 def refresh_data():
     get_stops(get_routes(refresh=True), refresh=True)
@@ -50,7 +50,7 @@ def read_stops_from_file():
         return {}
 
 
-def get_routes(refresh=False, route="bus", bbox=FLORIANOPOLIS):
+def get_routes(route, bbox, refresh=False):
     if refresh:
         print "Start with fresh routes"
         routes = {}
@@ -85,7 +85,7 @@ def get_routes(refresh=False, route="bus", bbox=FLORIANOPOLIS):
     return routes
 
 
-def get_route_masters(refresh=False, route="bus", bbox=FLORIANOPOLIS):
+def get_route_masters(route, bbox,refresh=False):
     if refresh:
         print "Start with fresh route masters"
         route_masters = {}

--- a/osmhelper/__init__.py
+++ b/osmhelper/__init__.py
@@ -12,6 +12,7 @@ from osmhelper.osm_stops import Stop
 
 CHECK_FOR_NON_PLATFORMS = False
 
+FLORIANOPOLIS = {"e":"-48.27117919921875", "n":"-27.215556209029675", "s":"-27.94103350326715", "w":"-49.0155029296875"}
 
 def refresh_data():
     get_stops(get_routes(refresh=True), refresh=True)
@@ -49,7 +50,7 @@ def read_stops_from_file():
         return {}
 
 
-def get_routes(refresh=False):
+def get_routes(refresh=False, route="bus", bbox=FLORIANOPOLIS):
     if refresh:
         print "Start with fresh routes"
         routes = {}
@@ -60,13 +61,13 @@ def get_routes(refresh=False):
 
     result = api.query("""
     <query type="relation">
-        <has-kv k="route" v="bus"/>
-        <bbox-query e="-48.27117919921875" n="-27.215556209029675" s="-27.94103350326715" w="-49.0155029296875"/>
+        <has-kv k="route" v="%s"/>
+        <bbox-query e="%s" n="%s" s="%s" w="%s"/>
     </query>
     <print/>
-    """)
+    """ % (route, bbox["e"], bbox["n"], bbox["s"], bbox["w"]))
 
-    route_masters = get_route_masters(refresh)
+    route_masters = get_route_masters(refresh, route, bbox)
 
     for rel in result.get_relations():
         get_route(routes, route_masters, rel)
@@ -82,7 +83,7 @@ def get_routes(refresh=False):
     return routes
 
 
-def get_route_masters(refresh=False):
+def get_route_masters(refresh=False, route="bus", bbox=FLORIANOPOLIS):
     if refresh:
         print "Start with fresh route masters"
         route_masters = {}
@@ -91,17 +92,17 @@ def get_route_masters(refresh=False):
 
     api = overpy.Overpass()
 
-    # get all route_master's in Floripa area
-    # start out from route=bus relations,
+    # get all route_master's in bbox area
+    # start out from "route" (bus, train) relations,
     # because searching directly for type=route_master does not work with overpass
     result = api.query("""
     <query type="relation">
-        <has-kv k="route" v="bus"/>
-        <bbox-query e="-48.27117919921875" n="-27.215556209029675" s="-27.94103350326715" w="-49.0155029296875"/>
+        <has-kv k="route" v="%s"/>
+        <bbox-query e="%s" n="%s" s="%s" w="%s"/>
     </query>
     <recurse type="relation-backwards"/>
     <print/>
-    """)
+    """ % (route, bbox["e"], bbox["n"], bbox["s"], bbox["w"]))
 
     for rel in result.get_relations():
 


### PR DESCRIPTION
Little modifications in code just to be able to work with a different bbox and route type (passed as parameters in some methods). The default usage of the code should work nice for Florianopolis bus routes. 

Note: This modifications are being used in the incofer2gtfs.py script of the forked osm2gtfs.