### PR TITLE
Improved finding of names for unnamed stops - #39

### DIFF
--- a/core/osm_stops.py
+++ b/core/osm_stops.py
@@ -7,7 +7,6 @@ STOP_REGEX = re.compile('(TICAN|TISAN|TICEN|TITRI|TILAG|TIRIO|TISAC).*')
 
 
 class Stop(object):
-    NO_NAME = "[Ponto sem nome]"
 
     def __init__(self, osm, stop_type, name=None, lat=None, lon=None):
         self.id = osm
@@ -62,23 +61,3 @@ class Stop(object):
         center_lon = degrees(atan2(y, x))
 
         return center_lat, center_lon
-
-    @staticmethod
-    def is_valid_stop_candidate(stop):
-        """Helper function to check if a stop candidate has a valid tagging
-
-        Returns True or False
-
-        """
-        if 'public_transport' in stop.tags:
-            if stop.tags['public_transport'] == 'platform':
-                return True
-            elif stop.tags['public_transport'] == 'station':
-                return True
-        elif 'highway' in stop.tags:
-            if stop.tags['highway'] == 'bus_stop':
-                return True
-        elif 'amenity' in stop.tags:
-            if stop.tags['amenity'] == 'bus_station':
-                return True
-        return False

--- a/creators/fenix/stops_creator_fenix.py
+++ b/creators/fenix/stops_creator_fenix.py
@@ -1,13 +1,8 @@
 # coding=utf-8
 
-import overpy
-import sys
 
-from transitfeed import util
 from creators.stops_creator import StopsCreator
-from core.cache import Cache
 from core.osm_routes import Route, RouteMaster
-from core.osm_stops import Stop
 
 
 class StopsCreatorFenix(StopsCreator):
@@ -19,14 +14,6 @@ class StopsCreatorFenix(StopsCreator):
 
         # add all stops to GTFS
         for stop in stops.values():
-
-            # If there is no name, query one intelligently from OSM
-            if stop.name == Stop.NO_NAME:
-                self.find_best_name_for_unnamed_stop(stop)
-                print stop
-
-                # Cache stops with newly created stop names
-                Cache.write_data('stops-' + data.selector, stops)
 
             # Add stop to GTFS object
             schedule.AddStop(
@@ -73,75 +60,3 @@ class StopsCreatorFenix(StopsCreator):
 
         else:
             raise RuntimeError("Unknown Route: " + str(route))
-
-    def find_best_name_for_unnamed_stop(self, stop):
-        """Define name for stop without explicit name based on sourroundings
-
-        """
-        api = overpy.Overpass()
-
-        result = api.query("""
-        <osm-script>
-          <query type="way">
-            <around lat="%s" lon="%s" radius="50.0"/>
-            <has-kv k="name" />
-            <has-kv modv="not" k="highway" v="trunk"/>
-            <has-kv modv="not" k="highway" v="primary"/>
-            <has-kv modv="not" k="highway" v="secondary"/>
-            <has-kv modv="not" k="amenity" v="bus_station"/>
-          </query>
-          <print order="quadtile"/>
-          <query type="node">
-            <around lat="%s" lon="%s" radius="50.0"/>
-            <has-kv k="name"/>
-            <has-kv modv="not" k="highway" v="bus_stop"/>
-          </query>
-          <print order="quadtile"/>
-        </osm-script>
-        """ % (stop.lat, stop.lon, stop.lat, stop.lon))
-
-        candidates = []
-
-        # get all node candidates
-        for node in result.get_nodes():
-            if 'name' in node.tags and node.tags["name"] is not None:
-                candidates.append(node)
-
-        # get way node candidates
-        for way in result.get_ways():
-            if 'name' in way.tags and way.tags["name"] is not None:
-                candidates.append(way)
-
-        # leave if no candidates
-        if len(candidates) == 0:
-            # give stop a different name, so we won't search again without
-            # refreshing data
-            stop.name = "Ponto sem nome"
-            return
-
-        # find closest candidate
-        winner = None
-        winner_distance = sys.maxint
-        for candidate in candidates:
-            if isinstance(candidate, overpy.Way):
-                lat, lon = Stop.get_center_of_nodes(
-                    candidate.get_nodes(resolve_missing=True))
-                distance = util.ApproximateDistance(
-                    lat,
-                    lon,
-                    stop.lat,
-                    stop.lon
-                )
-            else:
-                distance = util.ApproximateDistance(
-                    candidate.lat,
-                    candidate.lon,
-                    stop.lat,
-                    stop.lon
-                )
-            if distance < winner_distance:
-                winner = candidate
-                winner_distance = distance
-
-        # take name from winner
-        stop.name = winner.tags["name"].encode('utf-8')

--- a/fenix.json.example
+++ b/fenix.json.example
@@ -10,6 +10,10 @@
             "route": "bus"
         }
     },
+    "stops": {
+        "name_without": "Ponto sem nome",
+        "name_auto": "yes"
+    },
     "agency": {
         "agency_id": "BR-Floripa",
         "agency_name": "Consórcio Fênix",


### PR DESCRIPTION
Related to issue #39.

- Moved finding of names for unnamed stops logic from `FenixStopCreator` into `OsmHelper`
- Setting flag to search for unnamed stops  in config (`name_auto`)
- Introduced name for unnamed stops in config (`name_without`)
- Moved `add_shape()` from `Route` to `_generate_shape()` in `OsmHelper`
- Moved `is_valid_stop_candidate()` from `Stop` to `_is_valid_stop_candidate()` in `OsmHelper`