### PR TITLE
Flexibile start and end dates - #14

### DIFF
--- a/core/configuration.py
+++ b/core/configuration.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+
+import os
+import sys
+import json
+import datetime
+import logging
+from calendar import monthrange
+
+
+class Configuration(object):
+    """The Configuration class validates and prepares configuration data from
+    the config file for further use in the script.
+
+    """
+
+    def __init__(self, args):
+        """Contructor function
+
+        This function gets called when Configuration object are created.
+
+        Based on the configuration from the config file it validates and
+        prepares all mandatory configuration elements.
+
+        """
+        # Load config file from argument of standard location
+        self.config = self._load_config(args)
+
+        # Define name for output file
+        self.output = self._define_output_file(args)
+
+        # Validate and prepare start and end date
+        self._prepare_dates()
+
+    def _load_config(self, args):
+        """Loads the configuration. Either the standard location
+        (config.json) or a location specified as an command argument.
+
+        :return config: A dictionary of configuration data.
+
+        """
+        # Load config json file
+        if args.config is not None:
+            config = Configuration._load_config_file(args.config)
+        elif os.path.isfile('config.json'):
+            with open("config.json") as json_file:
+                config = Configuration._load_config_file(json_file)
+        else:
+            sys.stderr.write("Error: No config.json file found.\n")
+            sys.exit(0)
+
+        return config
+
+    @staticmethod
+    def _load_config_file(configfile):
+        """
+        Loads json from config file
+
+        :return config: A dictionary of configuration data.
+
+        """
+        try:
+            config = json.load(configfile)
+        except ValueError, e:
+            sys.stderr.write('Error: Config json file is invalid.\n')
+            print(e)
+            sys.exit(0)
+
+        return config
+
+    def _define_output_file(self, args):
+        """
+        Defines the filename for GTFS file to write.
+        Either from config file or command argument.
+
+        :return output: Filename for saving GTFS output file.
+
+        """
+        # Get and check filename for gtfs output
+        if args.output is not None:
+            output_file = args.output
+        elif 'output_file' in self.config:
+            output_file = self.config['output_file']
+        else:
+            sys.stderr.write('Error: No filename for gtfs file specified.\n')
+            sys.exit(0)
+
+        return output_file
+
+    def _prepare_dates(self):
+        """
+        Validate and prepare start and end date.
+        Either from config file or based on current date.
+
+        """
+        config = self.config
+
+        start_date = False
+        if 'start_date' in config['feed_info']:
+            try:
+                start_date = datetime.datetime.strptime(
+                    config['feed_info']['start_date'], "%Y%m%d")
+            except ValueError, e:
+                sys.stderr.write(
+                    'Warning: "start_date" from config file %s\n' % str(e))
+                pass
+
+        if not start_date:
+            # Use first of current month if no start date was specified
+            now = datetime.datetime.now()
+            start_date = datetime.date(day=1, month=now.month, year=now.year)
+            config['feed_info']['start_date'] = str(start_date.year) + \
+                str(start_date.month) + "01"
+            print("Using the generated start date: " +
+                  config['feed_info']['start_date'])
+
+        end_date = False
+        if 'end_date' in config['feed_info']:
+            try:
+                end_date = datetime.datetime.strptime(
+                    config['feed_info']['end_date'], "%Y%m%d")
+            except ValueError, e:
+                sys.stderr.write(
+                    'Warning: "end_date" from config file %s\n' % str(e))
+                pass
+
+        if not end_date:
+            # Define end date automatically one year from start date
+            end_date_year = start_date.year + 1
+            end_date_month = start_date.month - 1
+            end_date_day = monthrange(end_date_year, end_date_month)[1]
+            end_date = datetime.date(
+                day=end_date_day, month=end_date_month, year=end_date_year)
+            config['feed_info']['end_date'] = str(
+                end_date.year) + str(end_date.month) + str(end_date.day)
+            print("Using the generated end date: " +
+                  config['feed_info']['end_date'])
+
+        # Validate dates
+        if start_date > end_date:
+            sys.stderr.write('Error: End dates finishes before start date.\n')
+            sys.exit(0)
+        elif end_date - start_date > datetime.timedelta(days=364):
+            sys.stderr.write(
+                "Warning: Date range is more than one year.\n")

--- a/fenix.json.example
+++ b/fenix.json.example
@@ -22,9 +22,7 @@
     "feed_info": {
         "publisher_name": "Torsten Grote",
         "publisher_url": "https://transportr.grobox.de",
-        "version":  "0.1",
-        "start_date": "20160901",
-        "end_date": "20170831"
+        "version":  "0.1"
     },
     "output_file": "data/br-floripa.zip",
     "selector": "fenix"


### PR DESCRIPTION
Related to issue #14.

- Moved all config related things from main script into `Configuration` class.
- When no start date is defined in config file it takes the first day of the current month.
- When no end date is defined it uses the start date and builds related to it the end date to the last day of the one month before in one year in the future.
- Validates if start date is not after end date.
- Validates if date range is not more than one year.