### PR TITLE
Allow schedule source to be specified

### DIFF
--- a/osm2gtfs/core/cache.py
+++ b/osm2gtfs/core/cache.py
@@ -18,9 +18,9 @@ class Cache(object):
         hard drive.
 
         """
-        if not os.path.isdir('data'):  # checking is the dir exist
+        if not os.path.isdir('data'):
             os.mkdir('data')
-        with open('data/' + name + '.pkl', 'wb') as f:
+        with open(os.path.join('data', name + '.pkl'), 'wb') as f:
             pickle.dump(content, f, pickle.HIGHEST_PROTOCOL)
 
     @staticmethod
@@ -31,9 +31,40 @@ class Cache(object):
         file on the hard drive.
 
         """
-        if os.path.isfile('data/' + name + '.pkl'):
-            with open('data/' + name + '.pkl', 'rb') as f:
+        filename = os.path.join('data', name + '.pkl')
+        if os.path.isfile(filename):
+            with open(filename, 'rb') as f:
                 content = pickle.load(f)
             return content
         else:
             return {}
+
+    @staticmethod
+    def write_file(name, content):
+        """Function to write cache
+
+        Writes an object (content) with an indicated name to a file on the
+        hard drive.
+
+        """
+        if not os.path.isdir('data'):
+            os.mkdir('data')
+        with open(os.path.join('data', name), 'wb') as f:
+            f.write(content.read())
+
+    @staticmethod
+    def read_file(name):
+        """Function to read cache
+
+        Reads and returns an object (content) with an indicated name from a
+        file on the hard drive.
+
+        :return file: The read file, or an empty dictionary in case no file
+            was found
+        """
+        filename = os.path.join('data', name)
+        if os.path.isfile(filename):
+            with open(filename, 'rb') as f:
+                return f.read()
+        else:
+            return dict()

--- a/osm2gtfs/core/configuration.py
+++ b/osm2gtfs/core/configuration.py
@@ -4,7 +4,9 @@ import os
 import sys
 import json
 import datetime
+from urllib2 import urlopen
 from calendar import monthrange
+from osm2gtfs.core.cache import Cache
 
 
 class Configuration(object):
@@ -23,13 +25,68 @@ class Configuration(object):
 
         """
         # Load config file from argument of standard location
-        self.config = self._load_config(args)
+        self.data = self._load_config(args)
 
         # Define name for output file
         self.output = self._define_output_file(args)
 
         # Validate and prepare start and end date
         self._prepare_dates()
+
+        # Initiate variable for schedule source information
+        self._schedule_source = None
+
+    def get_schedule_source(self, refresh=False):
+        """Loads the schedule source information.
+
+        Loads a schedule source file from either a path or a url specified
+        in the config file
+
+        :return schedule_source: The schedule read from a file.
+
+        """
+
+        if 'schedule_source' not in self.data:
+            return None
+
+        else:
+            source_file = self.data['schedule_source']
+            cached_file = 'schedule-source-' + self.data['selector']
+
+            # Preferably return cached data about schedule
+            if refresh is False:
+                # Check if _schedule_source data is already present
+                if not self._schedule_source:
+                    # If not, try to get _schedule_source from file cache
+                    self._schedule_source = Cache.read_file(cached_file)
+                # Return cached data if found
+                if bool(self._schedule_source):
+                    return self._schedule_source
+
+            # No cached data was found or refresh was forced
+            print("Load schedule source information from " + source_file)
+
+            # Check if local file exists
+            if os.path.isfile(source_file):
+
+                # Open file and add to config object
+                with open(source_file, 'r') as f:
+                    schedule_source = f.read()
+
+            else:
+                # Check if it is a valid url
+                try:
+                    schedule_source_file = urlopen(source_file)
+                except ValueError:
+                    sys.stderr.write(
+                        "Error: Couldn't find schedule_source file.\n")
+                    sys.exit(0)
+                schedule_source = schedule_source_file
+
+        # Cache data
+        Cache.write_file(cached_file, schedule_source)
+        self._schedule_source = schedule_source
+        return self._schedule_source
 
     def _load_config(self, args):
         """Loads the configuration. Either the standard location
@@ -78,8 +135,8 @@ class Configuration(object):
         # Get and check filename for gtfs output
         if args.output is not None:
             output_file = args.output
-        elif 'output_file' in self.config:
-            output_file = self.config['output_file']
+        elif 'output_file' in self.data:
+            output_file = self.data['output_file']
         else:
             sys.stderr.write('Error: No filename for gtfs file specified.\n')
             sys.exit(0)
@@ -92,7 +149,7 @@ class Configuration(object):
         Either from config file or based on current date.
 
         """
-        config = self.config
+        config = self.data
 
         start_date = False
         if 'start_date' in config['feed_info']:
@@ -107,7 +164,7 @@ class Configuration(object):
             # Use first of current month if no start date was specified
             now = datetime.datetime.now()
             start_date = datetime.datetime.strptime(
-                            now.strftime('%Y%m') + "01", "%Y%m%d")
+                now.strftime('%Y%m') + "01", "%Y%m%d")
             config['feed_info']['start_date'] = now.strftime('%Y%m') + "01"
             print("Using the generated start date: " +
                   config['feed_info']['start_date'])

--- a/osm2gtfs/core/creator_factory.py
+++ b/osm2gtfs/core/creator_factory.py
@@ -5,6 +5,7 @@ from osm2gtfs.creators.agency_creator import AgencyCreator
 from osm2gtfs.creators.feed_info_creator import FeedInfoCreator
 from osm2gtfs.creators.routes_creator import RoutesCreator
 from osm2gtfs.creators.stops_creator import StopsCreator
+from osm2gtfs.creators.schedule_creator import ScheduleCreator
 from osm2gtfs.creators.trips_creator import TripsCreator
 
 
@@ -12,8 +13,8 @@ class CreatorFactory(object):
 
     def __init__(self, config):
         self.config = config
-        if 'selector' in config:
-            self.selector = config['selector']
+        if 'selector' in self.config.data:
+            self.selector = self.config.data['selector']
         else:
             self.selector = None
 
@@ -33,10 +34,10 @@ class CreatorFactory(object):
                 package="osm2gtfs")
             agency_creator_override = getattr(
                 module, "AgencyCreator" + selector.capitalize())
-            print "Agency creator: " + selector.capitalize()
+            print("Agency creator: " + selector.capitalize())
             return agency_creator_override(self.config)
         except ImportError:
-            print "Agency creator: Default"
+            print("Agency creator: Default")
             return AgencyCreator(self.config)
 
     def get_feed_info_creator(self):
@@ -47,10 +48,10 @@ class CreatorFactory(object):
                 package="osm2gtfs")
             feed_info_creator_override = getattr(
                 module, "FeedInfoCreator" + selector.capitalize())
-            print "Feed info creator: " + selector.capitalize()
+            print("Feed info creator: " + selector.capitalize())
             return feed_info_creator_override(self.config)
         except ImportError:
-            print "Feed info creator: Default"
+            print("Feed info creator: Default")
             return FeedInfoCreator(self.config)
 
     def get_routes_creator(self):
@@ -61,10 +62,10 @@ class CreatorFactory(object):
                 package="osm2gtfs")
             routes_creator_override = getattr(
                 module, "RoutesCreator" + selector.capitalize())
-            print "Routes creator: " + selector.capitalize()
+            print("Routes creator: " + selector.capitalize())
             return routes_creator_override(self.config)
         except ImportError:
-            print "Routes creator: Default"
+            print("Routes creator: Default")
             return RoutesCreator(self.config)
 
     def get_stops_creator(self):
@@ -75,11 +76,25 @@ class CreatorFactory(object):
                 package="osm2gtfs")
             stops_creator_override = getattr(
                 module, "StopsCreator" + selector.capitalize())
-            print "Stops creator: " + selector.capitalize()
+            print("Stops creator: " + selector.capitalize())
             return stops_creator_override(self.config)
         except ImportError:
-            print "Stops creator: Default"
+            print("Stops creator: Default")
             return StopsCreator(self.config)
+
+    def get_schedule_creator(self):
+        selector = self.selector
+        try:
+            module = importlib.import_module(
+                ".creators." + selector + ".schedule_creator_" + selector,
+                package="osm2gtfs")
+            schedule_creator_override = getattr(
+                module, "ScheduleCreator" + selector.capitalize())
+            print("Schedule creator: " + selector.capitalize())
+            return schedule_creator_override(self.config)
+        except ImportError:
+            print("Schedule creator: Default")
+            return ScheduleCreator(self.config)
 
     def get_trips_creator(self):
         selector = self.selector
@@ -89,8 +104,8 @@ class CreatorFactory(object):
                 package="osm2gtfs")
             trips_creator_override = getattr(
                 module, "TripsCreator" + selector.capitalize())
-            print "Trips creator: " + selector.capitalize()
+            print("Trips creator: " + selector.capitalize())
             return trips_creator_override(self.config)
         except ImportError:
-            print "Trips creator: Default"
+            print("Trips creator: Default")
             return TripsCreator(self.config)

--- a/osm2gtfs/core/osm_connector.py
+++ b/osm2gtfs/core/osm_connector.py
@@ -27,20 +27,20 @@ class OsmConnector(object):
         stops, that are going to be shared and used by the ther components
         of the program.
 
-        :param config: configuration information from the config file
+        :param config: configuration object including data from config file
 
         """
-        self.config = config
+        self.config = config.data
 
         # bbox from config file for querying
-        self.bbox = (str(config['query']['bbox']["s"]) + "," +
-                     str(config['query']['bbox']["w"]) + "," +
-                     str(config['query']['bbox']["n"]) + "," +
-                     str(config['query']['bbox']["e"]))
+        self.bbox = (str(self.config['query']['bbox']["s"]) + "," +
+                     str(self.config['query']['bbox']["w"]) + "," +
+                     str(self.config['query']['bbox']["n"]) + "," +
+                     str(self.config['query']['bbox']["e"]))
 
         # tags from config file for querying
         self.tags = ''
-        for key, value in config["query"].get("tags", {}).iteritems():
+        for key, value in self.config["query"].get("tags", {}).iteritems():
             self.tags += str('["' + key + '" = "' + value + '"]')
         if not self.tags:
             # fallback
@@ -50,18 +50,18 @@ class OsmConnector(object):
 
         # Define name for stops without one
         self.stop_no_name = 'No name'
-        if 'stops' in config and 'name_without' in config['stops']:
-            self.stop_no_name = config['stops']['name_without'].encode()
+        if 'stops' in self.config and 'name_without' in self.config['stops']:
+            self.stop_no_name = self.config['stops']['name_without'].encode()
 
         # Check if auto stop name logic should be used
         self.auto_stop_names = False
-        if 'stops' in config and 'name_auto' in config['stops']:
-            if config['stops']['name_auto'] == "yes":
+        if 'stops' in self.config and 'name_auto' in self.config['stops']:
+            if self.config['stops']['name_auto'] == "yes":
                 self.auto_stop_names = True
 
         # Selector
-        if 'selector' in config:
-            self.selector = config['selector']
+        if 'selector' in self.config:
+            self.selector = self.config['selector']
         else:
             self.selector = 'no-selector'
 

--- a/osm2gtfs/creators/accra/routes_creator_accra.py
+++ b/osm2gtfs/creators/accra/routes_creator_accra.py
@@ -5,7 +5,7 @@ from osm2gtfs.creators.routes_creator import RoutesCreator
 
 class RoutesCreatorAccra(RoutesCreator):
 
-    def add_routes_to_schedule(self, schedule, data):
+    def add_routes_to_feed(self, feed, data):
         # Get routes information
         data.get_routes()
 

--- a/osm2gtfs/creators/accra/schedule_creator_accra.py
+++ b/osm2gtfs/creators/accra/schedule_creator_accra.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+
+from osm2gtfs.creators.schedule_creator import ScheduleCreator
+
+
+class ScheduleCreatorAccra(ScheduleCreator):
+
+    def add_schedule_to_data(self, data):
+        # Don't use any schedule source
+        data.schedule = None

--- a/osm2gtfs/creators/accra/stops_creator_accra.py
+++ b/osm2gtfs/creators/accra/stops_creator_accra.py
@@ -30,8 +30,8 @@ def get_crow_fly_distance(from_tuple, to_tuple):
     return d * 1000  # meters
 
 
-def create_stop_area(stop_data, schedule):
-    gtfs_stop_area = schedule.AddStop(
+def create_stop_area(stop_data, feed):
+    gtfs_stop_area = feed.AddStop(
         lat=float(stop_data.lat),
         lng=float(stop_data.lon),
         name=stop_data.name,
@@ -41,8 +41,8 @@ def create_stop_area(stop_data, schedule):
     return gtfs_stop_area
 
 
-def create_stop_point(stop_data, schedule):
-    gtfs_stop_point = schedule.AddStop(
+def create_stop_point(stop_data, feed):
+    gtfs_stop_point = feed.AddStop(
         lat=float(stop_data.lat),
         lng=float(stop_data.lon),
         name=stop_data.name,
@@ -57,7 +57,7 @@ def get_stop_id(stop):
 
 class StopsCreatorAccra(StopsCreator):
 
-    def add_stops_to_schedule(self, schedule, data):
+    def add_stops_to_feed(self, feed, data):
         stops = data.get_stops()
         stops_by_name = {}
 
@@ -70,7 +70,7 @@ class StopsCreatorAccra(StopsCreator):
             stop_areas = []
 
             for a_stop_point in sorted(stops_by_name[a_stop_name], key=get_stop_id):
-                gtfs_stop_point = create_stop_point(a_stop_point, schedule)
+                gtfs_stop_point = create_stop_point(a_stop_point, feed)
                 stop_point_has_parent_location = False
                 for a_stop_area in stop_areas:
                     distance_to_parent_station = get_crow_fly_distance(
@@ -82,6 +82,6 @@ class StopsCreatorAccra(StopsCreator):
                         stop_point_has_parent_location = True
                         break
                 if not stop_point_has_parent_location:
-                    new_sa = create_stop_area(a_stop_point, schedule)
+                    new_sa = create_stop_area(a_stop_point, feed)
                     gtfs_stop_point.parent_station = new_sa.stop_id
                     stop_areas.append(new_sa)

--- a/osm2gtfs/creators/accra/trips_creator_accra.py
+++ b/osm2gtfs/creators/accra/trips_creator_accra.py
@@ -8,8 +8,8 @@ from osm2gtfs.creators.trips_creator import TripsCreator
 class TripsCreatorAccra(TripsCreator):
     service_weekday = None
 
-    def add_trips_to_schedule(self, schedule, data):
-        self.service_weekday = schedule.GetDefaultServicePeriod()
+    def add_trips_to_feed(self, feed, data):
+        self.service_weekday = feed.GetDefaultServicePeriod()
         self.service_weekday.SetStartDate(
             self.config['feed_info']['start_date'])
         self.service_weekday.SetEndDate(self.config['feed_info']['end_date'])
@@ -21,7 +21,7 @@ class TripsCreatorAccra(TripsCreator):
             if type(line).__name__ != "RouteMaster":
                 continue
 
-            line_gtfs = schedule.AddRoute(
+            line_gtfs = feed.AddRoute(
                 short_name=line.ref,
                 long_name=line.name.decode('utf8'),
                 # we change the route_long_name with the 'from' and 'to' tags
@@ -29,16 +29,16 @@ class TripsCreatorAccra(TripsCreator):
                 # the line code (route_short_name)
                 route_type="Bus",
                 route_id=line.id)
-            line_gtfs.agency_id = schedule.GetDefaultAgency().agency_id
+            line_gtfs.agency_id = feed.GetDefaultAgency().agency_id
             line_gtfs.route_desc = ""
             line_gtfs.route_color = "1779c2"
             line_gtfs.route_text_color = "ffffff"
 
             route_index = 0
             for a_route_ref, a_route in line.routes.iteritems():
-                trip_gtfs = line_gtfs.AddTrip(schedule)
+                trip_gtfs = line_gtfs.AddTrip(feed)
                 trip_gtfs.shape_id = TripsCreator.add_shape(
-                    schedule, a_route_ref, a_route)
+                    feed, a_route_ref, a_route)
                 trip_gtfs.direction_id = route_index % 2
                 route_index += 1
 
@@ -75,14 +75,14 @@ class TripsCreatorAccra(TripsCreator):
                     departure_time = datetime(2008, 11, 22, 6, 0, 0)
 
                     if index_stop == 0:
-                        trip_gtfs.AddStopTime(schedule.GetStop(
+                        trip_gtfs.AddStopTime(feed.GetStop(
                             str(stop_id)), stop_time=departure_time.strftime("%H:%M:%S"))
                     elif index_stop == len(a_route.stops) - 1:
                         departure_time += timedelta(minutes=TRAVEL_TIME)
-                        trip_gtfs.AddStopTime(schedule.GetStop(
+                        trip_gtfs.AddStopTime(feed.GetStop(
                             str(stop_id)), stop_time=departure_time.strftime("%H:%M:%S"))
                     else:
-                        trip_gtfs.AddStopTime(schedule.GetStop(str(stop_id)))
+                        trip_gtfs.AddStopTime(feed.GetStop(str(stop_id)))
 
                 for secs, stop_time, is_timepoint in trip_gtfs.GetTimeInterpolatedStops():
                     if not is_timepoint:

--- a/osm2gtfs/creators/agency_creator.py
+++ b/osm2gtfs/creators/agency_creator.py
@@ -7,7 +7,7 @@ import transitfeed
 class AgencyCreator(object):
 
     def __init__(self, config):
-        self.config = config
+        self.config = config.data
 
     def __repr__(self):
         rep = ""

--- a/osm2gtfs/creators/agency_creator.py
+++ b/osm2gtfs/creators/agency_creator.py
@@ -15,8 +15,8 @@ class AgencyCreator(object):
             rep += str(self.config) + " | "
         return rep
 
-    def add_agency_to_schedule(self, schedule):
-        schedule.AddAgencyObject(self.prepare_agency())
+    def add_agency_to_feed(self, feed):
+        feed.AddAgencyObject(self.prepare_agency())
 
     def prepare_agency(self):
         """

--- a/osm2gtfs/creators/feed_info_creator.py
+++ b/osm2gtfs/creators/feed_info_creator.py
@@ -14,14 +14,14 @@ class FeedInfoCreator(object):
             rep += str(self.config) + " | "
         return rep
 
-    def add_feed_info_to_schedule(self, schedule):
+    def add_feed_info_to_feed(self, feed):
         feed_info = self.prepare_feed_info()
-        schedule.AddFeedInfoObject(feed_info)
+        feed.AddFeedInfoObject(feed_info)
 
         # Missing feed_info workaround (https://github.com/google/transitfeed/issues/395)
         # noinspection PyProtectedMember
         # pylint: disable=protected-access
-        schedule.AddTableColumns('feed_info', feed_info._ColumnNames())
+        feed.AddTableColumns('feed_info', feed_info._ColumnNames())
 
     def prepare_feed_info(self):
         """

--- a/osm2gtfs/creators/feed_info_creator.py
+++ b/osm2gtfs/creators/feed_info_creator.py
@@ -6,7 +6,7 @@ import transitfeed
 class FeedInfoCreator(object):
 
     def __init__(self, config):
-        self.config = config
+        self.config = config.data
 
     def __repr__(self):
         rep = ""

--- a/osm2gtfs/creators/fenix/fenix.json
+++ b/osm2gtfs/creators/fenix/fenix.json
@@ -28,6 +28,7 @@
         "publisher_url": "https://transportr.grobox.de",
         "version":  "0.1"
     },
+    "schedule_source": "http://www.consorciofenix.com.br/api2/linhas.json",
     "output_file": "data/br-floripa.zip",
     "selector": "fenix"
 }

--- a/osm2gtfs/creators/fenix/routes_creator_fenix.py
+++ b/osm2gtfs/creators/fenix/routes_creator_fenix.py
@@ -5,7 +5,7 @@ from osm2gtfs.creators.routes_creator import RoutesCreator
 
 class RoutesCreatorFenix(RoutesCreator):
 
-    def add_routes_to_schedule(self, schedule, data):
+    def add_routes_to_feed(self, feed, data):
 
         # Get routes information
         data.get_routes()

--- a/osm2gtfs/creators/fenix/trips_creator_fenix.py
+++ b/osm2gtfs/creators/fenix/trips_creator_fenix.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
 import sys
-import json
 import re
 import transitfeed
 from datetime import timedelta, datetime
@@ -60,12 +59,8 @@ class TripsCreatorFenix(TripsCreator):
         feed.AddServicePeriodObject(self.service_saturday)
         feed.AddServicePeriodObject(self.service_sunday)
 
-        # Get Fenix data from JSON file
-        json_data = []
-        with open('data/linhas.json') as f:
-            for line in f:
-                json_data.append(json.loads(line))
-        linhas = json_data[0]['data']
+        # Get Fenix schedule data from source file
+        linhas = data.schedule['data']
 
         # Try to find OSM routes in Fenix data
         for route_ref, route in sorted(routes.iteritems()):

--- a/osm2gtfs/creators/fenix/trips_creator_fenix.py
+++ b/osm2gtfs/creators/fenix/trips_creator_fenix.py
@@ -54,11 +54,11 @@ class TripsCreatorFenix(TripsCreator):
 
         self.exceptions = None
 
-    def add_trips_to_schedule(self, schedule, data):
+    def add_trips_to_feed(self, feed, data):
         routes = data.routes
-        schedule.AddServicePeriodObject(self.service_weekday)
-        schedule.AddServicePeriodObject(self.service_saturday)
-        schedule.AddServicePeriodObject(self.service_sunday)
+        feed.AddServicePeriodObject(self.service_weekday)
+        feed.AddServicePeriodObject(self.service_saturday)
+        feed.AddServicePeriodObject(self.service_sunday)
 
         # Get Fenix data from JSON file
         json_data = []
@@ -81,16 +81,16 @@ class TripsCreatorFenix(TripsCreator):
                 duration_str = linha['tempo_de_percurso'].replace('aproximado', '')
                 (hours, tmp, minutes) = duration_str.partition(':')
                 route.set_duration(timedelta(hours=int(hours), minutes=int(minutes)))
-                self.add_route(schedule, route, linha['horarios'], linha['operacoes'])
+                self.add_route(feed, route, linha['horarios'], linha['operacoes'])
             elif route_ref not in BLACKLIST:
                 sys.stderr.write("Route not found in Fenix data: " + str(route) + "\n")
 
-    def add_route(self, schedule, route, horarios, operacoes):
-        line = schedule.AddRoute(
+    def add_route(self, feed, route, horarios, operacoes):
+        line = feed.AddRoute(
             short_name=route.ref,
             long_name=route.name.decode('utf8'),
             route_type="Bus")
-        line.agency_id = schedule.GetDefaultAgency().agency_id
+        line.agency_id = feed.GetDefaultAgency().agency_id
         line.route_desc = "TEST DESCRIPTION"
         line.route_url = "http://www.consorciofenix.com.br/horarios?q=" + str(route.ref)
         line.route_color = "1779c2"
@@ -126,20 +126,20 @@ class TripsCreatorFenix(TripsCreator):
             if date < self.start_date:
                 continue
 
-            service = self.get_exception_service_period(schedule, date, day)
+            service = self.get_exception_service_period(feed, date, day)
             if day == SATURDAY:
-                self.add_trips_by_day(schedule, line, service, route, saturday, SATURDAY)
+                self.add_trips_by_day(feed, line, service, route, saturday, SATURDAY)
             elif day == SUNDAY:
-                self.add_trips_by_day(schedule, line, service, route, sunday, SUNDAY)
+                self.add_trips_by_day(feed, line, service, route, sunday, SUNDAY)
             else:
                 sys.stderr.write("ERROR: Unknown day %s\n" % day)
 
         # regular schedule
-        self.add_trips_by_day(schedule, line, self.service_weekday, route, weekday, WEEKDAY)
-        self.add_trips_by_day(schedule, line, self.service_saturday, route, saturday, SATURDAY)
-        self.add_trips_by_day(schedule, line, self.service_sunday, route, sunday, SUNDAY)
+        self.add_trips_by_day(feed, line, self.service_weekday, route, weekday, WEEKDAY)
+        self.add_trips_by_day(feed, line, self.service_saturday, route, saturday, SATURDAY)
+        self.add_trips_by_day(feed, line, self.service_sunday, route, sunday, SUNDAY)
 
-    def add_trips_by_day(self, schedule, line, service, route, horarios, day):
+    def add_trips_by_day(self, feed, line, service, route, horarios, day):
         # check if we even have service
         if horarios is None or len(horarios) == 0:
             return
@@ -147,7 +147,7 @@ class TripsCreatorFenix(TripsCreator):
         if isinstance(route, RouteMaster):
             # recurse into "Ida" and "Volta" routes
             for sub_route in route.routes.values():
-                self.add_trips_by_day(schedule, line, service, sub_route, horarios, day)
+                self.add_trips_by_day(feed, line, service, sub_route, horarios, day)
             return
 
         # have at least two stops
@@ -169,12 +169,12 @@ class TripsCreatorFenix(TripsCreator):
         # get shape id
         shape_id = str(route.id)
         try:
-            schedule.GetShape(shape_id)
+            feed.GetShape(shape_id)
         except KeyError:
             shape = transitfeed.Shape(shape_id)
             for point in route.shape:
                 shape.AddPoint(lat=float(point["lat"]), lon=float(point["lon"]))
-            schedule.AddShapeObject(shape)
+            feed.AddShapeObject(shape)
 
         if len(horarios) > 1 and not route.has_proper_master():
             sys.stderr.write("Route should have a master: " + str(route) + "\n")
@@ -197,7 +197,7 @@ class TripsCreatorFenix(TripsCreator):
                 # TODO handle options
                 # opts = time_point[1]
 
-                trip = line.AddTrip(schedule, headsign=route.name, service_period=service)
+                trip = line.AddTrip(feed, headsign=route.name, service_period=service)
                 # add empty attributes to make navitia happy
                 trip.block_id = ""
                 trip.wheelchair_accessible = ""
@@ -206,12 +206,12 @@ class TripsCreatorFenix(TripsCreator):
                 trip.direction_id = ""
                 if route.ref == DEBUG_ROUTE:
                     print "ADD TRIP " + str(trip.trip_id) + ":"
-                self.add_trip_stops(schedule, trip, route, start_time, end_time)
+                self.add_trip_stops(feed, trip, route, start_time, end_time)
 
                 # interpolate times, because Navitia can not handle this itself
                 TripsCreator.interpolate_stop_times(trip)
 
-    def get_exception_service_period(self, schedule, date, day):
+    def get_exception_service_period(self, feed, date, day):
         date_string = date.strftime("%Y%m%d")
         if date.weekday() <= 4:
             self.service_weekday.SetDateHasService(date_string, False)
@@ -221,15 +221,15 @@ class TripsCreatorFenix(TripsCreator):
             self.service_sunday.SetDateHasService(date_string, False)
 
         service_id = date_string + "_" + day
-        if service_id in schedule.service_periods:
-            service = schedule.GetServicePeriod(service_id)
+        if service_id in feed.service_periods:
+            service = feed.GetServicePeriod(service_id)
         else:
             print("Created new schedule exception for %s with ID %s" % (str(date), service_id))
             service = transitfeed.ServicePeriod(service_id)
             service.SetStartDate(date_string)
             service.SetEndDate(date_string)
             service.SetDayOfWeekHasService(date.weekday())
-            schedule.AddServicePeriodObject(service)
+            feed.AddServicePeriodObject(service)
         return service
 
     @staticmethod
@@ -274,22 +274,22 @@ class TripsCreatorFenix(TripsCreator):
         return name
 
     @staticmethod
-    def add_trip_stops(schedule, trip, route, start_time, end_time):
+    def add_trip_stops(feed, trip, route, start_time, end_time):
         if isinstance(route, Route):
             i = 1
             for stop in route.stops:
                 if i == 1:
                     # timepoint="1" (Times are considered exact)
-                    trip.AddStopTime(schedule.GetStop(str(stop.id)), stop_time=start_time)
+                    trip.AddStopTime(feed.GetStop(str(stop.id)), stop_time=start_time)
                     if route.ref == DEBUG_ROUTE:
                         print "START: " + start_time + " at " + str(stop)
                 elif i == len(route.stops):
                     # timepoint="0" (Times are considered approximate)
-                    trip.AddStopTime(schedule.GetStop(str(stop.id)), stop_time=end_time)
+                    trip.AddStopTime(feed.GetStop(str(stop.id)), stop_time=end_time)
                     if route.ref == DEBUG_ROUTE:
                         print "END: " + end_time + " at " + str(stop)
                 else:
                     # timepoint="0" (Times are considered approximate)
-                    trip.AddStopTime(schedule.GetStop(str(stop.id)))
+                    trip.AddStopTime(feed.GetStop(str(stop.id)))
     #                print "INTER: " + str(stop)
                 i += 1

--- a/osm2gtfs/creators/incofer/incofer.json
+++ b/osm2gtfs/creators/incofer/incofer.json
@@ -32,6 +32,7 @@
         "start_date" : "20170202",
         "end_date": "20170910"
     },
+    "schedule_source": "https://raw.githubusercontent.com/jamescr/incofer-datos/master/input_incofer.json",
     "output_file": "data/cr-incofer.zip",
     "selector": "incofer"
 }

--- a/osm2gtfs/creators/incofer/routes_creator_incofer.py
+++ b/osm2gtfs/creators/incofer/routes_creator_incofer.py
@@ -5,7 +5,7 @@ from osm2gtfs.creators.routes_creator import RoutesCreator
 
 class RoutesCreatorIncofer(RoutesCreator):
 
-    def add_routes_to_schedule(self, schedule, data):
+    def add_routes_to_feed(self, feed, data):
 
         # Get routes information
         lines = data.get_routes()
@@ -15,7 +15,7 @@ class RoutesCreatorIncofer(RoutesCreator):
 
         # Loop through all lines (master_routes)
         for line_ref, line in sorted(lines.iteritems()):
-            route = schedule.AddRoute(
+            route = feed.AddRoute(
                 short_name=line.ref.encode('utf-8'),
                 long_name=line.name,
                 # TODO: infer transitfeed "route type" from OSM data
@@ -23,7 +23,7 @@ class RoutesCreatorIncofer(RoutesCreator):
                 route_id=line_ref)
 
             # AddRoute method add defaut agency as default
-            route.agency_id = schedule.GetDefaultAgency().agency_id
+            route.agency_id = feed.GetDefaultAgency().agency_id
 
             route.route_desc = "Esta línea está a prueba"
 

--- a/osm2gtfs/creators/incofer/trips_creator_incofer.py
+++ b/osm2gtfs/creators/incofer/trips_creator_incofer.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 
-import json
 from datetime import datetime
 
 import transitfeed
@@ -28,15 +27,15 @@ class TripsCreatorIncofer(TripsCreator):
                 shape_id = TripsCreator.add_shape(feed, itinerary_id, itinerary)
 
                 # service periods | días de opearación (c/u con sus horarios)
-                operations = self._get_itinerary_operation(itinerary)
+                operations = self._get_itinerary_operation(itinerary, data)
 
                 # operation (gtfs service period)
                 for operation in operations:
                     service_period = self._create_service_period(
                         feed, operation)
 
-                    horarios = load_times(itinerary, operation)
-                    estaciones = load_stations(itinerary, operation)
+                    horarios = load_times(itinerary, data, operation)
+                    estaciones = load_stations(itinerary, data, operation)
 
                     route = feed.GetRoute(line_id)
 
@@ -45,16 +44,12 @@ class TripsCreatorIncofer(TripsCreator):
                                         horarios)
         return
 
-    def _get_itinerary_operation(self, itinerary,
-                                 filename='data/input_incofer.json'):
+    def _get_itinerary_operation(self, itinerary, data):
         """
             Retorna un iterable (lista) de objetos str, cada uno un 'keyword'
             del día o días de servicio, cuyos viajes (estaciones y horarios) se
             incluyen en el archivo de entrada.
         """
-
-        input_file = open(filename)
-        data = json.load(input_file)
 
         fr = itinerary.fr.encode('utf-8')
         to = itinerary.to.encode('utf-8')
@@ -63,7 +58,7 @@ class TripsCreatorIncofer(TripsCreator):
 
         operations = []
 
-        for operation in data["itinerario"][itinerary.ref]:
+        for operation in data.schedule["itinerario"][itinerary.ref]:
             input_fr = operation["from"].encode('utf-8')
             input_to = operation["to"].encode('utf-8')
             if input_fr == fr and input_to == to:
@@ -143,12 +138,10 @@ def add_trips_for_route(feed, gtfs_route, itinerary, service_period,
     return
 
 
-def load_stations(route, operation, filename='data/input_incofer.json'):
-    input_file = open(filename)
-    input_data = json.load(input_file)
+def load_stations(route, data, operation):
 
     stations = []
-    for direction in input_data["itinerario"][route.ref]:
+    for direction in data.schedule["itinerario"][route.ref]:
         fr = direction["from"].encode('utf-8')
         to = direction["to"].encode('utf-8')
         data_operation = direction["operacion"].encode('utf-8')
@@ -165,13 +158,11 @@ def load_stations(route, operation, filename='data/input_incofer.json'):
     return stations
 
 
-def load_times(route, operation, filename='data/input_incofer.json'):
-    input_file = open(filename)
-    input_data = json.load(input_file)
+def load_times(route, data, operation):
 
-    # route_directions = input_data["itinerario"][route.ref]["horarios"]
+    # route_directions = data.schedule["itinerario"][route.ref]["horarios"]
     times = None
-    for direction in input_data["itinerario"][route.ref]:
+    for direction in data.schedule["itinerario"][route.ref]:
 
         fr = direction["from"].encode('utf-8')
         to = direction["to"].encode('utf-8')

--- a/osm2gtfs/creators/routes_creator.py
+++ b/osm2gtfs/creators/routes_creator.py
@@ -12,5 +12,5 @@ class RoutesCreator(object):
             rep += str(self.config) + " | "
         return rep
 
-    def add_routes_to_schedule(self, schedule, data):
+    def add_routes_to_feed(self, feed, data):
         raise NotImplementedError("Should have implemented this")

--- a/osm2gtfs/creators/routes_creator.py
+++ b/osm2gtfs/creators/routes_creator.py
@@ -4,7 +4,7 @@
 class RoutesCreator(object):
 
     def __init__(self, config):
-        self.config = config
+        self.config = config.data
 
     def __repr__(self):
         rep = ""

--- a/osm2gtfs/creators/schedule_creator.py
+++ b/osm2gtfs/creators/schedule_creator.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+
+import sys
+import json
+
+
+class ScheduleCreator(object):
+    """
+    The ScheduleCreator loads, validates and prepares configuration data from
+    the schedule source file for further use in the script.
+
+    More information about the standard schedule format:
+    https://github.com/grote/osm2gtfs/wiki/Schedule
+
+    """
+    def __init__(self, config):
+        self.config = config
+
+    def __repr__(self):
+        rep = ""
+        if self.config is not None:
+            rep += str(self.config) + " | "
+        return rep
+
+    def add_schedule_to_data(self, data):
+        """
+        This function adds the loaded schedule to the global data object.
+        """
+        schedule = self._load_schedule_source()
+        data.schedule = self._prepare_schedule(schedule)
+
+    def _load_schedule_source(self):
+        """
+        This function loads and verifies the content of the file.
+        """
+
+        schedule_source = self.config.get_schedule_source()
+
+        if schedule_source is None:
+            sys.stderr.write("Error: No schedule source found.\n")
+            sys.exit(0)
+
+        else:
+            try:
+                schedule = json.loads(schedule_source)
+            except ValueError, e:
+                sys.stderr.write('Error: Schedule file is invalid.\n')
+                print(e)
+                sys.exit(0)
+
+        return schedule
+
+    def _prepare_schedule(self, schedule):
+        """
+        This function prepares (if needed) the schedule for further use.
+        """
+        return schedule

--- a/osm2gtfs/creators/stops_creator.py
+++ b/osm2gtfs/creators/stops_creator.py
@@ -18,7 +18,6 @@ class StopsCreator(object):
         return rep
 
     def add_stops_to_feed(self, feed, data):
-
         # Get stops information
         stops = data.get_stops()
 
@@ -39,7 +38,6 @@ class StopsCreator(object):
         self.add_stops_to_routes(data)
 
     def add_stop(self, feed, stop, parent_station=None, is_station=False):
-
         stop_dict = {"stop_lat": float(stop.lat),
                      "stop_lon": float(stop.lon),
                      "stop_name": stop.name}
@@ -62,7 +60,6 @@ class StopsCreator(object):
         return stop
 
     def add_stops_to_routes(self, data):
-
         routes = data.routes
         stops = data.stops
 
@@ -75,8 +72,8 @@ class StopsCreator(object):
         return
 
     def _fill_stops(self, stops, route):
-        """Fill a route object with stop objects for of linked stop ids
-
+        """
+        Fill a route object with stop objects for of linked stop ids
         """
         if isinstance(route, Route):
             i = 0

--- a/osm2gtfs/creators/stops_creator.py
+++ b/osm2gtfs/creators/stops_creator.py
@@ -17,7 +17,7 @@ class StopsCreator(object):
             rep += str(self.config) + " | "
         return rep
 
-    def add_stops_to_schedule(self, schedule, data):
+    def add_stops_to_feed(self, feed, data):
 
         # Get stops information
         stops = data.get_stops()
@@ -26,19 +26,19 @@ class StopsCreator(object):
         for elem in stops.values():
             if type(elem) is StopArea:
                 if len(elem.stop_members) > 1:
-                    parent_station = self.add_stop(schedule, elem, None, True)
+                    parent_station = self.add_stop(feed, elem, None, True)
                     for stop in elem.stop_members.values():
-                        self.add_stop(schedule, stop, parent_station)
+                        self.add_stop(feed, stop, parent_station)
                 else:
                     stop = elem.stop_members.values()[0]
-                    self.add_stop(schedule, stop)
+                    self.add_stop(feed, stop)
             else:
-                self.add_stop(schedule, elem)
+                self.add_stop(feed, elem)
 
         # Add loose stop objects to route objects
         self.add_stops_to_routes(data)
 
-    def add_stop(self, schedule, stop, parent_station=None, is_station=False):
+    def add_stop(self, feed, stop, parent_station=None, is_station=False):
 
         stop_dict = {"stop_lat": float(stop.lat),
                      "stop_lon": float(stop.lon),
@@ -58,7 +58,7 @@ class StopsCreator(object):
 
         # Add stop to GTFS object
         stop = transitfeed.Stop(field_dict=stop_dict)
-        schedule.AddStopObject(stop)
+        feed.AddStopObject(stop)
         return stop
 
     def add_stops_to_routes(self, data):

--- a/osm2gtfs/creators/trips_creator.py
+++ b/osm2gtfs/creators/trips_creator.py
@@ -4,7 +4,7 @@
 class TripsCreator(object):
 
     def __init__(self, config):
-        self.config = config
+        self.config = config.data
 
     def __repr__(self):
         rep = ""

--- a/osm2gtfs/creators/trips_creator.py
+++ b/osm2gtfs/creators/trips_creator.py
@@ -12,7 +12,7 @@ class TripsCreator(object):
             rep += str(self.config) + " | "
         return rep
 
-    def add_trips_to_schedule(self, schedule, data):
+    def add_trips_to_feed(self, feed, data):
         raise NotImplementedError("Should have implemented this")
 
     @staticmethod
@@ -27,18 +27,18 @@ class TripsCreator(object):
                 trip.ReplaceStopTimeObject(stop_time)
 
     @staticmethod
-    def add_shape(schedule, route_id, osm_r):
+    def add_shape(feed, route_id, osm_r):
         """
         create GTFS shape and return shape_id to add on GTFS trip
         """
         import transitfeed
         shape_id = str(route_id)
         try:
-            schedule.GetShape(shape_id)
+            feed.GetShape(shape_id)
         except KeyError:
             shape = transitfeed.Shape(shape_id)
             for point in osm_r.shape:
                 shape.AddPoint(
                     lat=float(point["lat"]), lon=float(point["lon"]))
-            schedule.AddShapeObject(shape)
+            feed.AddShapeObject(shape)
         return shape_id

--- a/osm2gtfs/osm2gtfs.py
+++ b/osm2gtfs/osm2gtfs.py
@@ -50,7 +50,7 @@ def main():
         sys.exit(0)
 
     # Define (transitfeed) schedule object for GTFS creation
-    schedule = transitfeed.Schedule()
+    feed = transitfeed.Schedule()
 
     # Initiate creators for GTFS components through an object factory
     factory = CreatorFactory(config.config)
@@ -61,41 +61,41 @@ def main():
     trips_creator = factory.get_trips_creator()
 
     # Add data to schedule object
-    agency_creator.add_agency_to_schedule(schedule)
-    feed_info_creator.add_feed_info_to_schedule(schedule)
-    routes_creator.add_routes_to_schedule(schedule, data)
-    stops_creator.add_stops_to_schedule(schedule, data)
-    trips_creator.add_trips_to_schedule(schedule, data)
+    agency_creator.add_agency_to_feed(feed)
+    feed_info_creator.add_feed_info_to_feed(feed)
+    routes_creator.add_routes_to_feed(feed, data)
+    stops_creator.add_stops_to_feed(feed, data)
+    trips_creator.add_trips_to_feed(feed, data)
 
     # Validate GTFS
-    schedule.Validate(transitfeed.ProblemReporter())
+    feed.Validate(transitfeed.ProblemReporter())
 
     # Write GTFS
-    schedule.WriteGoogleTransitFeed(config.output)
+    feed.WriteGoogleTransitFeed(config.output)
 
     # Add feed_info.txt to GTFS
-    add_feed_info(schedule, config.output)
+    add_feed_info(feed, config.output)
 
     sys.exit()
 
 
 # noinspection PyProtectedMember
-def add_feed_info(schedule, output_file):
+def add_feed_info(feed, output_file):
     """
     Add feed_info.txt file to GTFS
     Workaround for https://github.com/google/transitfeed/issues/395
     """
-    if 'feed_info' not in schedule._table_columns:  # pylint: disable=protected-access
+    if 'feed_info' not in feed._table_columns:  # pylint: disable=protected-access
         return
 
     with transitfeed.zipfile.ZipFile(output_file, 'a') as archive:
         feed_info_string = transitfeed.StringIO.StringIO()
         writer = transitfeed.util.CsvUnicodeWriter(feed_info_string)
-        columns = schedule.GetTableColumns('feed_info')
+        columns = feed.GetTableColumns('feed_info')
         writer.writerow(columns)
-        writer.writerow([transitfeed.util.EncodeUnicode(schedule.feed_info[c]) for c in columns])
+        writer.writerow([transitfeed.util.EncodeUnicode(feed.feed_info[c]) for c in columns])
         # pylint: disable=protected-access
-        schedule._WriteArchiveString(archive, 'feed_info.txt', feed_info_string)
+        feed._WriteArchiveString(archive, 'feed_info.txt', feed_info_string)
 
 
 if __name__ == "__main__":

--- a/osm2gtfs/osm2gtfs.py
+++ b/osm2gtfs/osm2gtfs.py
@@ -24,6 +24,8 @@ group.add_argument('--refresh-routes', action="store_true",
                    help='Refresh OSM data for all routes')
 group.add_argument('--refresh-stops', action="store_true",
                    help='Refresh OSM data for all stops')
+group.add_argument('--refresh-schedule-source', action="store_true",
+                   help='Refresh data for time information')
 group.add_argument('--refresh-all', action="store_true",
                    help='Refresh all OSM data')
 args = parser.parse_args()
@@ -35,36 +37,37 @@ def main():
     config = Configuration(args)
 
     # Initiate OpenStreetMap helper containing data
-    data = OsmConnector(config.config)
+    data = OsmConnector(config)
 
     # Refresh argument option calls
     if args.refresh_routes:
         data.get_routes(refresh=True)
-        sys.exit(0)
     elif args.refresh_stops:
         data.get_stops(refresh=True)
-        sys.exit(0)
+    elif args.refresh_schedule_source:
+        config.get_schedule_source(refresh=True)
     elif args.refresh_all:
         data.get_routes(refresh=True)
         data.get_stops(refresh=True)
-        sys.exit(0)
 
-    # Define (transitfeed) schedule object for GTFS creation
+    # Define (transitfeed) object for GTFS creation
     feed = transitfeed.Schedule()
 
     # Initiate creators for GTFS components through an object factory
-    factory = CreatorFactory(config.config)
+    factory = CreatorFactory(config)
     agency_creator = factory.get_agency_creator()
     feed_info_creator = factory.get_feed_info_creator()
     routes_creator = factory.get_routes_creator()
     stops_creator = factory.get_stops_creator()
+    schedule_creator = factory.get_schedule_creator()
     trips_creator = factory.get_trips_creator()
 
-    # Add data to schedule object
+    # Add data to feed
     agency_creator.add_agency_to_feed(feed)
     feed_info_creator.add_feed_info_to_feed(feed)
     routes_creator.add_routes_to_feed(feed, data)
     stops_creator.add_stops_to_feed(feed, data)
+    schedule_creator.add_schedule_to_data(data)
     trips_creator.add_trips_to_feed(feed, data)
 
     # Validate GTFS

--- a/osm2gtfs/tests/tests_accra.py
+++ b/osm2gtfs/tests/tests_accra.py
@@ -81,10 +81,10 @@ class TestAccra(unittest.TestCase):
         args = Args(self.config_file)
         self.config = Configuration(args)
         # deactivation of Overpass calls for unnamed stops
-        self.config.config['stops']['name_auto'] = "no"
+        self.config.data['stops']['name_auto'] = "no"
 
     def test_refresh_routes_cache(self):
-        data = OsmConnector(self.config.config)
+        data = OsmConnector(self.config)
         cache_file = os.path.join(self.data_dir, "routes-accra.pkl")
         mocked_overpass_data_file = os.path.join(self.fixture_folder, "overpass-routes.xml")
         if os.path.isfile(cache_file):
@@ -100,7 +100,7 @@ class TestAccra(unittest.TestCase):
         self.assertEqual(len(routes), 277, 'Wrong count of routes in the cache file')
 
     def test_refresh_stops_cache(self):
-        data = OsmConnector(self.config.config)
+        data = OsmConnector(self.config)
         cache_file = os.path.join(self.data_dir, "stops-accra.pkl")
         mocked_overpass_data_file = os.path.join(self.fixture_folder, "overpass-stops.xml")
         if os.path.isfile(cache_file):
@@ -122,12 +122,12 @@ class TestAccra(unittest.TestCase):
         self.assertTrue(os.path.isfile(stops_file), "The stops cache file doesn't exists")
         self.assertTrue(os.path.isfile(routes_cache_file), "The routes cache file doesn't exists")
 
-        data = OsmConnector(self.config.config)
+        data = OsmConnector(self.config)
 
         # Define (transitfeed) schedule object for GTFS creation
         feed = transitfeed.Schedule()
         # Initiate creators for GTFS components through an object factory
-        factory = CreatorFactory(self.config.config)
+        factory = CreatorFactory(self.config)
         agency_creator = factory.get_agency_creator()
         feed_info_creator = factory.get_feed_info_creator()
         routes_creator = factory.get_routes_creator()

--- a/osm2gtfs/tests/tests_accra.py
+++ b/osm2gtfs/tests/tests_accra.py
@@ -125,7 +125,7 @@ class TestAccra(unittest.TestCase):
         data = OsmConnector(self.config.config)
 
         # Define (transitfeed) schedule object for GTFS creation
-        schedule = transitfeed.Schedule()
+        feed = transitfeed.Schedule()
         # Initiate creators for GTFS components through an object factory
         factory = CreatorFactory(self.config.config)
         agency_creator = factory.get_agency_creator()
@@ -135,14 +135,14 @@ class TestAccra(unittest.TestCase):
         trips_creator = factory.get_trips_creator()
 
         # Add data to schedule object
-        agency_creator.add_agency_to_schedule(schedule)
-        feed_info_creator.add_feed_info_to_schedule(schedule)
-        routes_creator.add_routes_to_schedule(schedule, data)
-        stops_creator.add_stops_to_schedule(schedule, data)
-        trips_creator.add_trips_to_schedule(schedule, data)
+        agency_creator.add_agency_to_feed(feed)
+        feed_info_creator.add_feed_info_to_feed(feed)
+        routes_creator.add_routes_to_feed(feed, data)
+        stops_creator.add_stops_to_feed(feed, data)
+        trips_creator.add_trips_to_feed(feed, data)
 
         # Write GTFS
-        schedule.WriteGoogleTransitFeed(self.config.output)
+        feed.WriteGoogleTransitFeed(self.config.output)
         gtfs_expected_result = os.path.join(self.fixture_folder, "accra_tests.zip.ref")
         gtfs_generated_result = os.path.join(self.data_dir, "accra_tests.zip")
         self.assertTrue(is_valid_gtfs(gtfs_generated_result), 'The generated GTFS is not valid')


### PR DESCRIPTION
Proposed solution for #80.

* Renamed (transitfeed) `schedule` object to `feed` variable name in osm2gtfs
* Introduced a `schedule_source` in the configuration file. Can be either a local path, a url to download any file to be used in the creators to get the time information in, or a "None" (like in Accra) to omit processing of any schedule file.
* Introduced a `--refresh-schedule-source` argument to re-download a cached schedule file.
* Introduced a `schedule_creator`, which allows  the input file to be load, verified and even manipulated - if needed. The simple standard `schedule_creator` takes a regular json file, but others could be supported with an overridden `schedule_creator_*`)
* Added source file information in the configuration file for each of the existing creators
* Make Incofer use the standard `schedule_creator`; make Fenix rely on the `schedule_source` information of the config file.