### PR TITLE
Add config file for Esteli, Nicaragua network

### DIFF
--- a/osm2gtfs/creators/esteli/esteli.json
+++ b/osm2gtfs/creators/esteli/esteli.json
@@ -1,0 +1,35 @@
+{
+    "query": {
+        "bbox": {
+            "n": "13.1308234",
+            "s": "13.0534171",
+            "e": "-86.3197351",
+            "w": "-86.3999775"
+        },
+        "tags": {
+            "route": "bus",
+            "network": "NI-Estelí"
+        }
+    },
+    "stops": {
+        "name_without": "Parada sin nombre",
+        "name_auto": "no"
+    },
+    "agency": {
+        "agency_id": "NI-Estelí",
+        "agency_name": "Estelí",
+        "agency_url": "https://wiki.openstreetmap.org/wiki/ES:Wikiproyecto_Nicaragua/Transporte_p%C3%BAblico/Estel%C3%AD",
+        "agency_timezone": "America/Managua",
+        "agency_lang": "es",
+        "agency_phone": "",
+        "agency_fare_url": ""
+    },
+    "feed_info": {
+        "publisher_name": "MapaNica.net",
+        "publisher_url": "https://mapanica.net",
+        "version":  "0.1"
+    },
+    "schedule_source": "https://github.com/mapanica/pt-data-esteli/raw/master/timetable.json",
+    "output_file": "data/ni-esteli.zip",
+    "selector": "esteli"
+}


### PR DESCRIPTION
This PR is provided by @AltNico. It is in a similar situation like #88 and should be merged in after:

* #91 - Allow schedule source to be defined
* #89 - Data structure
* TBD - Standard creators ([almost ready](https://github.com/mapanica/osm2gtfs/tree/default-creators) and waiting for the other two to be approved)

The reason for posting it here, is because this is already working in local setups and should be in the pipeline to get into upstream.