### PR TITLE
unifies object type after reading the schedule source files

### DIFF
--- a/osm2gtfs/core/cache.py
+++ b/osm2gtfs/core/cache.py
@@ -50,7 +50,7 @@ class Cache(object):
         if not os.path.isdir('data'):
             os.mkdir('data')
         with open(os.path.join('data', name), 'wb') as f:
-            f.write(content.read())
+            f.write(content)
 
     @staticmethod
     def read_file(name):

--- a/osm2gtfs/core/configuration.py
+++ b/osm2gtfs/core/configuration.py
@@ -81,7 +81,7 @@ class Configuration(object):
                     sys.stderr.write(
                         "Error: Couldn't find schedule_source file.\n")
                     sys.exit(0)
-                schedule_source = schedule_source_file
+                schedule_source = schedule_source_file.read()
 
         # Cache data
         Cache.write_file(cached_file, schedule_source)


### PR DESCRIPTION
In configuration.py the `schedule_source` variable type varies depending if it is a URL or a local file. The former is a file-like and the latter a string. The write_file method in cache.py assumes a file object and tries to read() from the content param, this causes an error when the schedule_source of the configuration file is a local file (a str). With this PR the type of the `schedule_source` is str in both cases. 