### PR TITLE
 Support multiple values for the same OSM tag

### DIFF
--- a/osm2gtfs/core/osm_connector.py
+++ b/osm2gtfs/core/osm_connector.py
@@ -42,7 +42,11 @@ class OsmConnector(object):
         # tags from config file for querying
         self.tags = ''
         for key, value in self.config["query"].get("tags", {}).iteritems():
-            self.tags += unicode('["' + key + '" = "' + value + '"]')
+            if isinstance(value, list):
+                value = '^' + '$|^'.join(value) + '$'
+                self.tags += unicode('["' + key + '" ~ "' + value + '"]')
+            else:
+                self.tags += unicode('["' + key + '" = "' + value + '"]')
         if not self.tags:
             # fallback
             self.tags = '["public_transport:version" = "2"]'


### PR DESCRIPTION
I've elaborated this little code change to support a `config.json` file as follows:
```json
{
    "query": {
        "tags": {
            "public_transport:version": "2",
            "operator":  [
                "Incofer",
                "Alpizar S.A."
            ]
        }
    }
}
```

This generated the following Overpass query:
```qml
relation
  (9.8346,-84.2418,10.0365,-83.8507)
  ["public_transport:version" = "2"]
  ["operator" ~ "Incofer|Alpizar S.A."];
(._;);
out body;
```

Fixes #110 