### PR TITLE
Fix encoding errors

### DIFF
--- a/osm2gtfs/creators/routes_creator.py
+++ b/osm2gtfs/creators/routes_creator.py
@@ -55,7 +55,7 @@ class RoutesCreator(object):
         Returns the long name for the use in the GTFS feed.
         Can be easily overridden in any creator.
         """
-        return route.name
+        return route.name.encode('utf-8')
 
     def _define_route_type(self, route):
         """

--- a/osm2gtfs/creators/trips_creator.py
+++ b/osm2gtfs/creators/trips_creator.py
@@ -34,8 +34,7 @@ class TripsCreator(object):
         # Go though all lines
         for line_id, line in data.routes.iteritems():
 
-            print("\nGenerating schedule for line: [" + str(
-                line_id) + "] - " + line.name)
+            print("\nGenerating schedule for line: [" + line_id + "] - " + line.name)
 
             # Loop through it's itineraries
             itineraries = line.get_itineraries()
@@ -62,7 +61,7 @@ class TripsCreator(object):
                             feed, itinerary, line, trip_builder, shape_id)
 
                 # Print out status messge about added trips
-                print(" Itinerary: [" + str(itinerary.route_id) + "] " +
+                print(" Itinerary: [" + itinerary.route_id.encode("utf-8") + "] " +
                       itinerary.to.encode("utf-8") + " (added " + str(
                           trips_count) + " trips, serving " + str(
                               len(itinerary.get_stops())) + " stops) - " +


### PR DESCRIPTION
While working on the countrywide NicaraguaCreator, I've found some odd python 2 encoding errors:
* `transitfeed`'s validator expects `route_long_name` and `route_short_name` to have the same encoding. That's why I changed the `RoutesCreator`.
* `str` expects only ASCII values, if the `route_id` contains non-ASCII chars, it throws an error. These are the changes to `TripsCreator`.

This PR should fix them both.