### PR TITLE
Remove unused stops and routes

### DIFF
--- a/osm2gtfs/creators/routes_creator.py
+++ b/osm2gtfs/creators/routes_creator.py
@@ -38,6 +38,24 @@ class RoutesCreator(object):
             gtfs_route.route_text_color = self._define_route_text_color(route)
         return
 
+    def remove_unused_routes_from_feed(self, feed):
+        """
+        This function removes every route which does not contain any trip
+        from the final GTFS.
+        It is called after the whole GTFS creation inside the main program.
+        """
+        removed = 0
+        for route_id, route in feed.routes.items():
+            if len(route.GetPatternIdTripDict()) == 0:
+                removed += 1
+                del feed.routes[route_id]
+        if removed == 0:
+            pass
+        elif removed == 1:
+            print("Removed 1 unused route")
+        else:
+            print("Removed %d unused routes" % removed)
+
     def _define_route_id(self, route):
         """
         Returns the route_id for the use in the GTFS feed.

--- a/osm2gtfs/creators/stops_creator.py
+++ b/osm2gtfs/creators/stops_creator.py
@@ -41,6 +41,24 @@ class StopsCreator(object):
             # Add stop to feed
             gtfs_stop_id = self._add_stop_to_feed(stop, feed)
 
+    def remove_unused_stops_from_feed(self, feed):
+        """
+        This function removes every stop which is not used by any trip
+        from the final GTFS.
+        It is called after the whole GTFS creation inside the main program.
+        """
+        removed = 0
+        for stop_id, stop in feed.stops.items():
+            if stop.location_type == 0 and not stop.GetTrips(feed):
+                removed += 1
+                del feed.stops[stop_id]
+        if removed == 0:
+            pass
+        elif removed == 1:
+            print("Removed 1 unused stop")
+        else:
+            print("Removed %d unused stops" % removed)
+
     def _add_stop_to_feed(self, stop, feed):
         """
         This function adds a single Stop or Station object as a stop to GTFS.

--- a/osm2gtfs/osm2gtfs.py
+++ b/osm2gtfs/osm2gtfs.py
@@ -76,6 +76,10 @@ def main():
     schedule_creator.add_schedule_to_data(data)
     trips_creator.add_trips_to_feed(feed, data)
 
+    # Remove unused data from feed
+    stops_creator.remove_unused_stops_from_feed(feed)
+    routes_creator.remove_unused_routes_from_feed(feed)
+
     # Validate GTFS
     feed.Validate(transitfeed.ProblemReporter())
 


### PR DESCRIPTION
This PR adds the possibility to remove unused stops and routes from the final _GTFS_ file. In order to allow #118, there could be easily added an argument switch.