### PR TITLE
Better warning message for unused stops in stop areas/stations

### DIFF
--- a/osm2gtfs/core/osm_connector.py
+++ b/osm2gtfs/core/osm_connector.py
@@ -519,10 +519,10 @@ class OsmConnector(object):
                     members[identifier] = self.stops['regular'][identifier]
                 else:
                     sys.stderr.write(
-                        "Error: Station member was not found in data")
-                    sys.stderr.write("https://osm.org/relation/" +
+                        "Note: Unused station member in stop area:\n")
+                    sys.stderr.write("  https://osm.org/relation/" +
                                      str(stop_area.id) + "\n")
-                    sys.stderr.write("https://osm.org/node/" +
+                    sys.stderr.write("  https://osm.org/node/" +
                                      str(member.ref) + "\n")
         if len(members) < 1:
             # Stop areas with only one stop, are not stations they just


### PR DESCRIPTION
Unused members in stop areas/stations are common. Especially in the scenario when stations serve buses that are part of different GTFSes, like having one for a urban buses and one for interurban buses. Therefore this should be a "Note" rather than an "Error" and the wording can be more explanatory. Alternatively we could also consider to drop the message entirely.