### PR TITLE
Improve reporting of transformation of stop areas (OSM) to stations (GTFS)

### DIFF
--- a/osm2gtfs/core/osm_connector.py
+++ b/osm2gtfs/core/osm_connector.py
@@ -529,14 +529,14 @@ class OsmConnector(object):
             # group different elements of one stop together.
             sys.stderr.write(
                 "Error: Station with no members has been discarted:\n")
-            sys.stderr.write("https://osm.org/relation/" +
+            sys.stderr.write(" https://osm.org/relation/" +
                              str(stop_area.id) + "\n")
             return None
 
         elif len(members) == 1:
             sys.stderr.write(
-                "Warning: Station has only one platform and is discarted\n")
-            sys.stderr.write("https://osm.org/relation/" +
+                "Note: OSM stop area has only one platform and can't be used as a GTFS station\n")
+            sys.stderr.write(" https://osm.org/relation/" +
                              str(stop_area.id) + "\n")
             return None
 
@@ -544,7 +544,7 @@ class OsmConnector(object):
         if 'name' not in stop_area.tags:
             sys.stderr.write("Warning: Stop area without name." +
                              " Please fix in OpenStreetMap\n")
-            sys.stderr.write("https://osm.org/relation/" +
+            sys.stderr.write(" https://osm.org/relation/" +
                              str(stop_area.id) + "\n")
             stop_area.name = self.stop_no_name
         else:
@@ -566,6 +566,12 @@ class OsmConnector(object):
                           name=stop_area.name, lat=stop_area.lat,
                           lon=stop_area.lon)
         station.set_members(members)
+
+        sys.stderr.write(
+            "Note: Stop area (OSM) has been used to create a station (GTFS):\n")
+        sys.stderr.write(" https://osm.org/relation/" +
+                         str(stop_area.id) + "\n")
+
         return station
 
     def _query_routes(self):


### PR DESCRIPTION
When stop areas from OSM are transformed into GTFS stations, there are several different cases that are checked and reported. While in OSM a stop_area can (probably should) also be used to unite a `stop_position` and only one single `platform`, in GTFS the definition of stations requires several platforms to exist. Therefore a "Warning" should be changed to a "Note" and another "Note" is included for successful station creation.