### PR TITLE
Avoid warnings about malformed station on routes relations

### DIFF
--- a/osm2gtfs/core/osm_connector.py
+++ b/osm2gtfs/core/osm_connector.py
@@ -482,22 +482,24 @@ class OsmConnector(object):
         Returns a initiated Station object from raw data
 
         """
-
-        # Check tagging whether this is a stop area.
-        if 'public_transport' not in stop_area.tags:
-            sys.stderr.write(
-                "Warning: Potential station has no public_transport tag.\n")
-            sys.stderr.write(
-                " Please fix on OSM: https://osm.org/" + osm_type + "/" + str(
-                    stop_area.id) + "\n")
+        # Check relation to be a station or used differently
+        if 'route' in stop_area.tags:
             return None
-        elif stop_area.tags['public_transport'] != 'stop_area':
-            sys.stderr.write(
-                "Warning: Potential station is not tagged as stop_area.\n")
-            sys.stderr.write(
-                " Please fix on OSM: https://osm.org/" + osm_type + "/" + str(
-                    stop_area.id) + "\n")
-            return None
+        else:
+            if 'public_transport' not in stop_area.tags:
+                sys.stderr.write(
+                    "Warning: Potential station has no public_transport tag.\n")
+                sys.stderr.write(
+                    " Please fix on OSM: https://osm.org/" + osm_type + "/" + str(
+                        stop_area.id) + "\n")
+                return None
+            elif stop_area.tags['public_transport'] != 'stop_area':
+                sys.stderr.write(
+                    "Warning: Potential station is not tagged as stop_area.\n")
+                sys.stderr.write(
+                    " Please fix on OSM: https://osm.org/" + osm_type + "/" + str(
+                        stop_area.id) + "\n")
+                return None
 
         # Analzyse member objects (stops) of this stop area
         members = {}


### PR DESCRIPTION
Currently when checking the relations coming from OSM for suitable `stop_areas` to create `stations`, the relations that include the routes themselves are checked and throw an error, that they are no good stop_areas. This PR proposes an additional check to avoid misleading warning.